### PR TITLE
Setting metastore.warehouse.dir to /stackable/warehouse

### DIFF
--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -274,6 +274,12 @@ impl HiveState {
                         data.insert(property_name.to_string(), Some(property_value.to_string()));
                     }
 
+                    // TODO: make configurable
+                    data.insert(
+                        "hive.metastore.warehouse.dir".to_string(),
+                        Some("/stackable/warehouse".to_string()),
+                    );
+
                     config_maps_data.insert(
                         file_name.clone(),
                         stackable_operator::product_config::writer::to_hadoop_xml(data.iter()),


### PR DESCRIPTION
## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
