### PR TITLE
Adapt code to adhere to ADR18 & Move integration tests back to operator repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ All notable changes to this project will be documented in this file.
 
 - `operator-rs` `0.10.0` -> `0.21.0` ([#137], [#142], [#168], [#179]).
 - Adapted S3 connection to operator-rs provided structs ([#179]).
-
+- [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#xxx])
+- 
 [#137]: https://github.com/stackabletech/hive-operator/pull/137
 [#142]: https://github.com/stackabletech/hive-operator/pull/142
 [#168]: https://github.com/stackabletech/hive-operator/pull/168
 [#179]: https://github.com/stackabletech/hive-operator/pull/179
+[#xxx]: https://github.com/stackabletech/hive-operator/pull/xxx
 
 ## [0.5.0] - 2022-02-14
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -88,6 +88,11 @@ metastore:
 
 == Examples
 
+Please note that the version you need to specify is not only the version of Apache Hive which you want to roll out, but has to be amended with a Stackable version as shown.
+This Stackable version is the version of the underlying container image which is used to execute the processes.
+For a list of available versions please check our https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable%2Fhive%2Ftags[image registry].
+It should generally be safe to simply use the latest image version that is available.
+
 .Create a single node Apache Hive Metastore cluster using Derby:
 [source,yaml]
 ----
@@ -97,7 +102,7 @@ kind: HiveCluster
 metadata:
   name: simple-hive-derby
 spec:
-  version: 2.3.9
+  version: 2.3.9-stackable0.4.0
   metastore:
     roleGroups:
       default:
@@ -133,12 +138,13 @@ Then, connect to localhost:9001 and login with the user `minio-access-key` and p
 Deploy the hive cluster:
 [source,yaml]
 ----
+---
 apiVersion: hive.stackable.tech/v1alpha1
 kind: HiveCluster
 metadata:
   name: simple-hive-derby
 spec:
-  version: 2.3.9
+  version: 2.3.9-stackable0.4.0
   s3:
     inline:
       host: minio

--- a/examples/simple-hive-cluster-postgres-s3.yaml
+++ b/examples/simple-hive-cluster-postgres-s3.yaml
@@ -16,7 +16,7 @@ kind: HiveCluster
 metadata:
   name: simple-hive-postgres
 spec:
-  version: 2.3.9
+  version: 2.3.9-stackable0.4.0
   s3:
     inline:
       host: test-minio

--- a/examples/simple-hive-cluster.yaml
+++ b/examples/simple-hive-cluster.yaml
@@ -4,7 +4,7 @@ kind: HiveCluster
 metadata:
   name: simple-hive-derby
 spec:
-  version: 2.3.9
+  version: 2.3.9-stackable0.4.0
   metastore:
     roleGroups:
       default:

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -499,7 +499,7 @@ fn build_metastore_rolegroup_statefulset(
 
     let hive_version = hive_version(hive)?;
     let image = format!(
-        "docker.stackable.tech/stackable/hive:{}-stackable0",
+        "docker.stackable.tech/stackable/hive:{}",
         hive_version
     );
 

--- a/tests/templates/kuttl/smoke/00-install-minio.yaml
+++ b/tests/templates/kuttl/smoke/00-install-minio.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: >-
+      helm install test-minio
+      --namespace $NAMESPACE
+      --set mode=standalone
+      --set replicas=1
+      --set persistence.enabled=false
+      --set buckets[0].name=test,buckets[0].policy=none
+      --set users[0].accessKey=minio-access-key,users[0].secretKey=minio-secret-key,users[0].policy=readwrite
+      --set resources.requests.memory=1Gi
+      --repo https://charts.min.io/ minio

--- a/tests/templates/kuttl/smoke/01-assert.yaml
+++ b/tests/templates/kuttl/smoke/01-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-postgres
+timeout: 600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hive-postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hive-postgresql
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/smoke/01-install-postgres.yaml.j2
+++ b/tests/templates/kuttl/smoke/01-install-postgres.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: >-
+      helm install hive
+      --version={{ test_scenario['values']['postgres'] }}
+      --namespace $NAMESPACE
+      --set postgresqlUsername=hive
+      --set postgresqlPassword=hive
+      --set postgresqlDatabase=hive
+      --repo https://charts.bitnami.com/bitnami postgresql

--- a/tests/templates/kuttl/smoke/10-assert.yaml
+++ b/tests/templates/kuttl/smoke/10-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: install-test-hive-derby
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-hive-postgres-metastore-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/smoke/10-install-hive.yaml.j2
+++ b/tests/templates/kuttl/smoke/10-install-hive.yaml.j2
@@ -1,0 +1,47 @@
+---
+apiVersion: hive.stackable.tech/v1alpha1
+kind: HiveCluster
+metadata:
+  name: test-hive-postgres
+spec:
+  version: {{ test_scenario['values']['hive'] }}
+  s3:
+    inline:
+      host: test-minio
+      port: 9000
+      accessStyle: Path
+      credentials:
+        secretClass: test-hive-s3-secret-class
+  metastore:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/os: linux
+        replicas: 1
+        config:
+          database:
+            connString: jdbc:postgresql://hive-postgresql:5432/hive
+            user: hive
+            password: hive
+            dbType: postgres
+---
+apiVersion: secrets.stackable.tech/v1alpha1
+kind: SecretClass
+metadata:
+  name: test-hive-s3-secret-class
+spec:
+  backend:
+    k8sSearch:
+      searchNamespace:
+        pod: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-hive-s3-secret
+  labels:
+    secrets.stackable.tech/class: test-hive-s3-secret-class
+stringData:
+  accessKey: minio-access-key
+  secretKey: minio-secret-key

--- a/tests/templates/kuttl/smoke/20-assert.yaml
+++ b/tests/templates/kuttl/smoke/20-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: test-metastore
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-metastore
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/smoke/20-install-test-metastore.yaml
+++ b/tests/templates/kuttl/smoke/20-install-test-metastore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-metastore
+  labels:
+    app: test-metastore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-metastore
+  template:
+    metadata:
+      labels:
+        app: test-metastore
+    spec:
+      containers:
+        - name: test-metastore
+          image: python:3.10-bullseye
+          stdin: true
+          tty: true

--- a/tests/templates/kuttl/smoke/30-assert.yaml
+++ b/tests/templates/kuttl/smoke/30-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: test-regorule
+commands:
+  - script: kubectl exec -n $NAMESPACE test-metastore-0 -- python /tmp/test_metastore.py -n $NAMESPACE

--- a/tests/templates/kuttl/smoke/30-prepare-test-metastore.yaml
+++ b/tests/templates/kuttl/smoke/30-prepare-test-metastore.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl cp -n $NAMESPACE ./test_metastore.py  test-metastore-0:/tmp
+  - script: kubectl cp -n $NAMESPACE ./requirements.txt test-metastore-0:/tmp
+  - script: kubectl exec -n $NAMESPACE test-metastore-0 -- pip install --user -r /tmp/requirements.txt

--- a/tests/templates/kuttl/smoke/requirements.txt
+++ b/tests/templates/kuttl/smoke/requirements.txt
@@ -1,0 +1,2 @@
+hive-metastore-client==1.0.9
+thrift==0.13.0 # Needs to match the version from hive-metastore-client

--- a/tests/templates/kuttl/smoke/test_metastore.py
+++ b/tests/templates/kuttl/smoke/test_metastore.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from hive_metastore_client import HiveMetastoreClient
+from hive_metastore_client.builders import (
+    DatabaseBuilder,
+    ColumnBuilder,
+    SerDeInfoBuilder,
+    StorageDescriptorBuilder,
+    TableBuilder,
+)
+from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (
+    FieldSchema,
+)
+import argparse
+
+
+def table(db_name, table_name, location):
+    columns = [
+        ColumnBuilder("id", "string", "col comment").build()
+    ]
+
+    serde_info = SerDeInfoBuilder(
+        serialization_lib="org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    ).build()
+
+    storage_descriptor = StorageDescriptorBuilder(
+        columns=columns,
+        location=location,
+        input_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+        output_format="org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+        serde_info=serde_info,
+    ).build()
+
+    test_table = TableBuilder(
+        db_name=db_name,
+        table_name=table_name,
+        storage_descriptor=storage_descriptor,
+    ).build()
+
+    return test_table
+
+
+if __name__ == '__main__':
+    all_args = argparse.ArgumentParser(description="Test hive metastore.")
+    all_args.add_argument("-p", "--port", help="Metastore server port", default="9083")
+    all_args.add_argument("-d", "--database", help="Test DB name", default="test_metastore")
+    all_args.add_argument("-n", "--namespace", help="The namespace to run in", required=True)
+    args = vars(all_args.parse_args())
+
+    namespace = args["namespace"]
+    database_name = args["database"]
+    port = args["port"]
+    local_test_table_name = "one_column_table"
+    s3_test_table_name = "s3_one_column_table"
+    s3_test_table_name_wrong_bucket = "s3_one_column_table_wrong_buckets"
+    host = 'test-hive-postgres-metastore-default-0.test-hive-postgres-metastore-default.' + namespace + '.svc.cluster.local'
+    # Creating database object using builder
+    database = DatabaseBuilder(database_name).build()
+
+    with HiveMetastoreClient(host, port) as hive_client:
+        hive_client.create_database_if_not_exists(database)
+
+        # Local access
+        hive_client.create_table(table(database_name, local_test_table_name, f"/stackable/warehouse/location_{database_name}_{local_test_table_name}"))
+        schema = hive_client.get_schema(db_name=database_name, table_name=local_test_table_name)
+        expected = [FieldSchema(name='id', type='string', comment='col comment')]
+        if schema != expected:
+            print("[ERROR]: Received local schema " + str(schema) + " - expected schema: " + expected)
+            exit(-1)
+
+        # S3 access
+        hive_client.create_external_table(table(database_name, s3_test_table_name, "s3a://test/"))
+        schema = hive_client.get_schema(db_name=database_name, table_name=s3_test_table_name)
+        expected = [FieldSchema(name='id', type='string', comment='col comment')]
+        if schema != expected:
+            print("[ERROR]: Received s3 schema " + str(schema) + " - expected schema: " + expected)
+            exit(-1)
+
+        # Wrong S3 bucket
+        try:
+            hive_client.create_external_table(table(database_name, s3_test_table_name_wrong_bucket, "s3a://wrongbucket/"))
+            # should not reach here
+            exit(-1)
+        except Exception as ex:
+            print("[SUCCESS]: Could not read from non existent bucket: {0}".format(ex))
+
+        print("[SUCCESS] Test finished successfully!")
+        exit(0)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -1,0 +1,13 @@
+---
+dimensions:
+  - name: postgres
+    values:
+      - "10"
+  - name: hive
+    values:
+      - 2.3.9-stackable0.4.0
+tests:
+  - name: smoke
+    dimensions:
+      - postgres
+      - hive


### PR DESCRIPTION
# Description

This contains a breaking change, since the version that is specified for Hive now has to include a stackable image version.

Previously the version could be specified as "version: 3.2.1" and the operator simply added the stackable version to this. But going forward we have decided that the image version has to be explictly specified, so it will now have to be "version: 3.2.1-stackable-0.1.0" or similar.

This is in accordance with ADR18 (https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html).

Also moved the integration test back into this repository.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
