### PR TITLE
[Merged by Bors] - Add temporary attribute to support using ClusterIP instead of NodePort service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Improved, tested getting started guide via script ([#225]).
+- Add temporary attribute to support using ClusterIP instead of NodePort service type ([#237]).
 
 ### Changed
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#213]: https://github.com/stackabletech/hive-operator/pull/213
 [#220]: https://github.com/stackabletech/hive-operator/pull/220
 [#225]: https://github.com/stackabletech/hive-operator/pull/225
+[#237]: https://github.com/stackabletech/hive-operator/pull/237
 
 ## [0.6.0] - 2022-06-30
 

--- a/deploy/crd/hivecluster.crd.yaml
+++ b/deploy/crd/hivecluster.crd.yaml
@@ -270,6 +270,13 @@ spec:
                     reference:
                       type: string
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/deploy/helm/hive-operator/crds/crds.yaml
+++ b/deploy/helm/hive-operator/crds/crds.yaml
@@ -272,6 +272,13 @@ spec:
                     reference:
                       type: string
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -273,6 +273,13 @@ spec:
                     reference:
                       type: string
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -31,6 +31,7 @@ pub const STACKABLE_TRUST_STORE_PASSWORD: &str = "changeit";
 pub const CERTS_DIR: &str = "/stackable/certificates/";
 
 #[derive(Clone, CustomResource, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 #[kube(
     group = "hive.stackable.tech",
     version = "v1alpha1",
@@ -55,6 +56,11 @@ pub struct HiveClusterSpec {
     pub metastore: Option<Role<MetaStoreConfig>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub s3: Option<S3ConnectionDef>,
+    /// Specify the type of the created kubernetes service.
+    /// This attribute will be removed in a future release when listener-operator is finished.
+    /// Use with caution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_type: Option<ServiceType>,
 }
 
 #[derive(strum::Display)]
@@ -112,6 +118,20 @@ impl MetaStoreConfig {
     pub const S3_SECRET_KEY: &'static str = "fs.s3a.secret.key";
     pub const S3_SSL_ENABLED: &'static str = "fs.s3a.connection.ssl.enabled";
     pub const S3_PATH_STYLE_ACCESS: &'static str = "fs.s3a.path.style.access";
+}
+
+// TODO: Temporary solution until listener-operator is finished
+#[derive(Clone, Debug, Display, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ServiceType {
+    NodePort,
+    ClusterIP,
+}
+
+impl Default for ServiceType {
+    fn default() -> Self {
+        Self::NodePort
+    }
 }
 
 #[derive(

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -283,7 +283,13 @@ pub fn build_metastore_role_service(hive: &HiveCluster) -> Result<Service> {
         spec: Some(ServiceSpec {
             ports: Some(service_ports()),
             selector: Some(role_selector_labels(hive, APP_NAME, &role_name)),
-            type_: Some("NodePort".to_string()),
+            type_: Some(
+                hive.spec
+                    .service_type
+                    .clone()
+                    .unwrap_or_default()
+                    .to_string(),
+            ),
             ..ServiceSpec::default()
         }),
         status: None,


### PR DESCRIPTION

# Description

Fixes https://github.com/stackabletech/hive-operator/issues/235


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
