### PR TITLE
[Merged by Bors] - Use testing-tools instead of the python base image.

### DIFF
--- a/tests/templates/kuttl/smoke/20-install-test-metastore.yaml
+++ b/tests/templates/kuttl/smoke/20-install-test-metastore.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: test-metastore
-          image: python:3.10-bullseye
+          image: docker.stackable.tech/stackable/testing-tools:0.1.0-stackable0.1.0
           stdin: true
           tty: true

--- a/tests/templates/kuttl/smoke/30-prepare-test-metastore.yaml
+++ b/tests/templates/kuttl/smoke/30-prepare-test-metastore.yaml
@@ -3,5 +3,3 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl cp -n $NAMESPACE ./test_metastore.py  test-metastore-0:/tmp
-  - script: kubectl cp -n $NAMESPACE ./requirements.txt test-metastore-0:/tmp
-  - script: kubectl exec -n $NAMESPACE test-metastore-0 -- pip install --user -r /tmp/requirements.txt

--- a/tests/templates/kuttl/smoke/requirements.txt
+++ b/tests/templates/kuttl/smoke/requirements.txt
@@ -1,2 +1,0 @@
-hive-metastore-client==1.0.9
-thrift==0.13.0 # Needs to match the version from hive-metastore-client


### PR DESCRIPTION
:green_circle: IONOS : https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hive-operator-it-custom/10/

This is part of the effort to [reduce integration tests flakiness](https://github.com/stackabletech/t2/issues/368).