### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -50,17 +50,25 @@ tests:
     dimensions:
       - hive-latest
 suites:
-  - name: latest
+  - name: nightly
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
+          - name: s3-use-tls
+            expr: "true"
+  - name: smoke-latest
     select:
       - smoke
+    patch:
+      - dimensions:
+          - expr: last
   - name: openshift
     patch:
       - dimensions:
           - expr: last
       - dimensions:
+          - expr: last
           - name: openshift
+            expr: "true"
+          - name: s3-use-tls
             expr: "true"


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62
```
(stackable) ➜  hive-operator git:(feat/nightly-suite) ✗ beku -s nightly     
INFO:root:Expanding test case id [smoke_postgres-12.5.6_hive-3.1.3-stackable0.0.0-dev_openshift-false_s3-use-tls-true]
INFO:root:Expanding test case id [resources_hive-3.1.3-stackable0.0.0-dev]
INFO:root:Expanding test case id [orphaned-resources_hive-latest-3.1.3-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_postgres-12.5.6_hive-3.1.3-stackable0.0.0-dev_openshift-false]
INFO:root:Expanding test case id [cluster-operation_hive-latest-3.1.3-stackable0.0.0-dev]
```
```
(stackable) ➜  hive-operator git:(feat/nightly-suite) ✗ beku -s smoke-latest               
INFO:root:Expanding test case id [smoke_postgres-12.5.6_hive-3.1.3-stackable0.0.0-dev_openshift-false_s3-use-tls-false]
```
```
(stackable) ➜  hive-operator git:(feat/nightly-suite) ✗ beku -s openshift   
INFO:root:Expanding test case id [smoke_postgres-12.5.6_hive-3.1.3-stackable0.0.0-dev_openshift-true_s3-use-tls-true]
INFO:root:Expanding test case id [resources_hive-3.1.3-stackable0.0.0-dev]
INFO:root:Expanding test case id [orphaned-resources_hive-latest-3.1.3-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_postgres-12.5.6_hive-3.1.3-stackable0.0.0-dev_openshift-true]
INFO:root:Expanding test case id [cluster-operation_hive-latest-3.1.3-stackable0.0.0-dev]
```
