### PR TITLE
Use service in discovery configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - `vector` `0.26.0` -> `0.33.0` ([#361], [#377]).
 - `operator-rs` `0.44.0` -> `0.55.0` ([#360], [#376], [#377]).
 - jmx-exporter now referenced via soft link without version ([#377]).
-- Service discovery no exposes the cluster service to enable HA ([#382]).
+- Service discovery now exposes the cluster service to enable HA ([#382]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `vector` `0.26.0` -> `0.33.0` ([#361], [#377]).
 - `operator-rs` `0.44.0` -> `0.55.0` ([#360], [#376], [#377]).
 - jmx-exporter now referenced via soft link without version ([#377]).
+- Service discovery no exposes the cluster service to enable HA ([#382]).
 
 ### Removed
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#365]: https://github.com/stackabletech/hive-operator/pull/365
 [#376]: https://github.com/stackabletech/hive-operator/pull/376
 [#377]: https://github.com/stackabletech/hive-operator/pull/377
+[#382]: https://github.com/stackabletech/hive-operator/pull/382
 
 ## [23.7.0] - 2023-07-14
 

--- a/docs/modules/hive/pages/discovery.adoc
+++ b/docs/modules/hive/pages/discovery.adoc
@@ -5,7 +5,7 @@
 
 = Discovery
 
-The Stackable Operator for Apache Hive publishes a discovery https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`], which exposes a client configuration bundle that allows access to the Apache Hive cluster.
+The Stackable Operator for Apache Hive publishes a discovery https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmap-v1-core[`ConfigMap`], which exposes a client configuration bundle that allows access to the Apache Hive cluster.
 
 The bundle includes an Apache Thrift connection string to access the Hive Metastore service. This string may be used by other operators or tools to configure their products with access to Hive. Access is limited to services within the same Kubernetes cluster.
 
@@ -21,10 +21,16 @@ metadata:
   name: {clusterName} # <1>
   namespace: {namespace} # <2>
 spec:
+  clusterConfig:
+    database:
+      connString: jdbc:postgresql://postgresql:5432/hive
+      user: hive
+      password: hive
+      dbType: postgres
   metastore:
     roleGroups:
       default: # <3>
-  [...]
+        replicas: 2
 ----
 <1> The name of the Hive cluster, which is also the name of the created discovery `ConfigMap`.
 <2> The namespace of the discovery `ConfigMap`.
@@ -34,20 +40,27 @@ The resulting discovery `ConfigMap` is `{namespace}/{clusterName}`.
 
 == Contents
 
+=== Internal access
+
 The `{namespace}/{clusterName}` discovery `ConfigMap` contains the following fields where `{clusterName}` represents the name, `{namespace}` the namespace of the cluster and `{roleGroup}` a role group of the `metastore` role:
 
 `HIVE`::
 ====
-Contains the thrift protocol connection string for the Hive metastore:
+Contains the thrift protocol connection string for the Hive metastore service:
 
 [subs="attributes"]
-  thrift://{clusterName}-metastore-{roleGroup}-0.{clusterName}-metastore-{roleGroup}.{namespace}.svc.cluster.local:{metastorePort}
+  thrift://{clusterName}.{namespace}.svc.cluster.local:{metastorePort}
+====
 
-or
+WARNING: Using the Hive metastore in high availability mode (replicas > 1) does not work with Derby but instead requires a proper configured database like PostgreSQL or MySQL.
 
-[subs="attributes"]
-  thrift://{clusterName}-metastore-{roleGroup}-0.{clusterName}-metastore-{roleGroup}.{namespace}.svc.cluster.local:{metastorePort}
-  thrift://{clusterName}-metastore-{roleGroup}-1.{clusterName}-metastore-{roleGroup}.{namespace}.svc.cluster.local:{metastorePort}
+=== External access
 
-for the role group `replicas` greater than one (two in this case), which should be avoided since the metastore instances do not sync between each other.
+If `spec.clusterConfig.listenerClass` is set to `external-unstable` an additional ConfigMap is generated to expose external access to the cluster. This discovery ConfigMap is reachable via `{namespace}/{clusterName}-nodeport`.
+
+====
+Contains the thrift protocol connection string for the Hive metastore NodePort service:
+
+  thrift://<node-ip>:<nodeport>
+  thrift://<other-node-ip>:<nodeport>
 ====

--- a/docs/modules/hive/pages/discovery.adoc
+++ b/docs/modules/hive/pages/discovery.adoc
@@ -52,7 +52,7 @@ Contains the thrift protocol connection string for the Hive metastore service:
   thrift://{clusterName}.{namespace}.svc.cluster.local:{metastorePort}
 ====
 
-WARNING: Using the Hive metastore in high availability mode (replicas > 1) does not work with Derby but instead requires a proper configured database like PostgreSQL or MySQL.
+WARNING: Using the Hive metastore in high availability mode (replicas > 1) does not work with Derby but instead requires a properly configured database like PostgreSQL or MySQL.
 
 === External access
 

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -103,7 +103,7 @@ pub async fn build_discovery_configmaps(
 
 /// Build a discovery [`ConfigMap`] containing information about how to connect to a certain [`HiveCluster`]
 ///
-/// `hosts` will usually come from either [`pod_hosts`] or [`nodeport_hosts`].
+/// `hosts` will usually come from the cluster role service or [`nodeport_hosts`].
 fn build_discovery_configmap(
     name: &str,
     owner: &impl Resource<DynamicType = ()>,

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -25,10 +25,6 @@ pub enum Error {
     },
     #[snafu(display("chroot path {chroot} was relative (must be absolute)"))]
     RelativeChroot { chroot: String },
-    #[snafu(display("failed to list expected pods"))]
-    ExpectedPods {
-        source: stackable_hive_crd::NoNamespaceError,
-    },
     #[snafu(display("could not build discovery config map for {obj_ref}"))]
     DiscoveryConfigMap {
         source: stackable_operator::error::Error,
@@ -69,13 +65,19 @@ pub async fn build_discovery_configmaps(
         .name
         .as_ref()
         .context(InvalidOwnerNameForDiscoveryConfigMapSnafu)?;
+    let namespace = owner
+        .meta()
+        .namespace
+        .as_deref()
+        .context(NoNamespaceSnafu)?;
     let mut discovery_configmaps = vec![build_discovery_configmap(
         name,
         owner,
         hive,
         resolved_product_image,
         chroot,
-        pod_hosts(hive)?,
+        // TODO: make domain configurable
+        vec![(format!("{name}.{namespace}.svc.cluster.local"), HIVE_PORT)],
     )?];
 
     // TODO: Temporary solution until listener-operator is finished
@@ -143,14 +145,6 @@ fn build_discovery_configmap(
         .with_context(|_| DiscoveryConfigMapSnafu {
             obj_ref: ObjectRef::from_obj(hive),
         })
-}
-
-/// Lists all Pods FQDNs expected to host the [`HiveCluster`]
-fn pod_hosts(hive: &HiveCluster) -> Result<impl IntoIterator<Item = (String, u16)> + '_, Error> {
-    Ok(hive
-        .pods()
-        .context(ExpectedPodsSnafu)?
-        .map(|pod_ref| (pod_ref.fqdn(), HIVE_PORT)))
 }
 
 /// Lists all nodes currently hosting Pods participating in the [`Service`]


### PR DESCRIPTION
# Description

- Use metastore service instead of single pod references in discovery config map to enable HA

fixes https://github.com/stackabletech/hive-operator/issues/380

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [ ] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
