### PR TITLE
fix: stackablectl arguments in getting_started.sh

### DIFF
--- a/docs/modules/hive/examples/getting_started/getting_started.sh
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh
@@ -82,8 +82,8 @@ fi
 echo "Installing MinIO and PostgreSQL with stackablectl"
 # tag::stackablectl-install-minio-postgres-stack[]
 stackablectl \
---additional-stacks-file stackablectl-hive-postgres-minio-stack.yaml \
---additional-releases-file release.yaml \
+--stack-file stackablectl-hive-postgres-minio-stack.yaml \
+--release-file release.yaml \
 stack install hive-minio-postgres
 # end::stackablectl-install-minio-postgres-stack[]
 ;;


### PR DESCRIPTION
# Description

This makes the getting_started script work with the new [stackablectl][1] from [stackable-cockpit][2].

[1]: https://github.com/stackabletech/stackable-cockpit/blob/5837276d8c1e587faa73a43da62cbab67e072b8c/rust/stackablectl/src/args/file.rs#L19-L45
[2]: https://github.com/stackabletech/stackable-cockpit

