### PR TITLE
fix(docs): Fix the h2 to a h1 title

### DIFF
--- a/docs/modules/hive/pages/usage-guide/resources.adoc
+++ b/docs/modules/hive/pages/usage-guide/resources.adoc
@@ -1,4 +1,4 @@
-== Resource Requests
+= Resource requests
 
 include::home:concepts:stackable_resource_requests.adoc[]
 


### PR DESCRIPTION
This fixes an incorrect title seen here: https://docs.stackable.tech/home/stable/hive/usage-guide/resources
