### PR TITLE
chore: bump hdfs version to 3.4.0

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -29,7 +29,7 @@ dimensions:
       # - 4.0.0,docker.stackable.tech/sandbox/hive:4.0.0-stackable0.0.0-dev
   - name: hdfs-latest
     values:
-      - 3.3.6
+      - 3.4.0
   - name: zookeeper-latest
     values:
       - 3.9.2


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/835

```
--- PASS: kuttl (442.13s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-4.0.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (426.80s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-3.1.3_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (441.33s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
