### PR TITLE
fix: Bump default memory reservation to 768Mi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Default to OCI for image metadata and product image selection ([#561]).
+- Increase default memory reservation to `768Mi` to avoid OOMKilled ([#578]).
 
 ### Fixed
 
@@ -29,6 +30,7 @@ All notable changes to this project will be documented in this file.
 [#561]: https://github.com/stackabletech/hive-operator/pull/561
 [#572]: https://github.com/stackabletech/hive-operator/pull/572
 [#574]: https://github.com/stackabletech/hive-operator/pull/574
+[#578]: https://github.com/stackabletech/hive-operator/pull/578
 
 ## [24.11.1] - 2025-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Default to OCI for image metadata and product image selection ([#561]).
-- Increase default memory reservation to `768Mi` to avoid OOMKilled ([#578]).
+- Increase default memory reservation to `768Mi` to avoid `OOMKilled` ([#578]).
 
 ### Fixed
 

--- a/docs/modules/hive/pages/usage-guide/resources.adoc
+++ b/docs/modules/hive/pages/usage-guide/resources.adoc
@@ -7,7 +7,7 @@ A minimal HA setup consisting of 2 Hive metastore instances has the following ht
 
 * `100m` CPU request
 * `3000m` CPU limit
-* `1280m` memory request and limit
+* `1792Mi` memory request and limit
 
 Of course, additional services, require additional resources. For Stackable components, see the corresponding documentation on further resource requirements.
 
@@ -22,10 +22,10 @@ metastore:
         resources:
           requests:
             cpu: "250m"
-            memory: "512Mi"
+            memory: "768Mi"
           limits:
             cpu: "1000m"
-            memory: "512Mi"
+            memory: "768Mi"
 ----
 
 The operator may configure an additional container for log aggregation. This is done when log aggregation is configured as described in xref:concepts:logging.adoc[]. The resources for this container cannot be configured using the mechanism described above. Use xref:home:concepts:overrides.adoc#_pod_overrides[podOverrides] for this purpose.

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -127,7 +127,7 @@ mod tests {
             -Djavax.net.ssl.trustStorePassword=changeit \
             -Djavax.net.ssl.trustStoreType=pkcs12"
         );
-        assert_eq!(hadoop_heapsize_env, "409");
+        assert_eq!(hadoop_heapsize_env, "614");
     }
 
     #[test]

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -475,7 +475,7 @@ impl MetaStoreConfig {
                     max: Some(Quantity("1000m".to_owned())),
                 },
                 memory: MemoryLimitsFragment {
-                    limit: Some(Quantity("512Mi".to_owned())),
+                    limit: Some(Quantity("768Mi".to_owned())),
                     runtime_limits: NoRuntimeLimitsFragment {},
                 },
                 storage: MetastoreStorageConfigFragment {

--- a/tests/templates/kuttl/kerberos-hdfs/60-assert.yaml.j2
+++ b/tests/templates/kuttl/kerberos-hdfs/60-assert.yaml.j2
@@ -15,10 +15,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 768Mi
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 768Mi
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
         - name: vector
 {% endif %}

--- a/tests/templates/kuttl/kerberos-s3/60-assert.yaml.j2
+++ b/tests/templates/kuttl/kerberos-s3/60-assert.yaml.j2
@@ -15,10 +15,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 768Mi
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 768Mi
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
         - name: vector
 {% endif %}

--- a/tests/templates/kuttl/smoke/60-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/60-assert.yaml.j2
@@ -15,10 +15,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 768Mi
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 768Mi
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
         - name: vector
 {% endif %}


### PR DESCRIPTION
# Description

Increase the default memory reservation to `768Mi` to avoid OOMKilled.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
