### PR TITLE
fix(docs)

### DIFF
--- a/docs/modules/hive/examples/getting_started/getting_started.sh
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh
@@ -42,29 +42,29 @@ helm install --wait hive-operator stackable-dev/hive-operator --version 0.0.0-de
 echo "Install minio for S3"
 # tag::helm-install-minio[]
 helm install minio \
---version 4.0.2 \
---namespace default \
---set mode=standalone \
---set replicas=1 \
---set persistence.enabled=false \
---set "buckets[0].name=hive,buckets[0].policy=none" \
---set "users[0].accessKey=hive,users[0].secretKey=hivehive,users[0].policy=readwrite" \
---set resources.requests.memory=1Gi \
---set service.type=NodePort,service.nodePort=null \
---set consoleService.type=NodePort,consoleService.nodePort=null \
---repo https://charts.min.io/ minio
+  --version 5.4.0 \
+  --namespace default \
+  --set mode=standalone \
+  --set replicas=1 \
+  --set persistence.enabled=false \
+  --set buckets[0].name=hive,buckets[0].policy=none \
+  --set users[0].accessKey=hive,users[0].secretKey=hivehive,users[0].policy=readwrite \
+  --set resources.requests.memory=1Gi \
+  --set service.type=NodePort,service.nodePort=null \
+  --set consoleService.type=NodePort,consoleService.nodePort=null \
+  --repo https://charts.min.io/ minio
 # end::helm-install-minio[]
 
 echo "Install postgres for Hive"
 # tag::helm-install-postgres[]
-helm install postgresql \
---version 12.1.5 \
---namespace default \
---set auth.username=hive \
---set auth.password=hive \
---set auth.database=hive \
---set primary.extendedConfiguration="password_encryption=md5" \
---repo https://charts.bitnami.com/bitnami postgresql
+helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version 16.5.0 \
+  --namespace default \
+  --set auth.username=hive \
+  --set auth.password=hive \
+  --set auth.database=hive \
+  --set primary.extendedConfiguration="password_encryption=md5" \
+  --wait
 # end::helm-install-postgres[]
 ;;
 "stackablectl")

--- a/docs/modules/hive/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh.j2
@@ -42,29 +42,29 @@ helm install --wait hive-operator {{ helm.repo_name }}/hive-operator --version {
 echo "Install minio for S3"
 # tag::helm-install-minio[]
 helm install minio \
---version {{ versions.minio }} \
---namespace default \
---set mode=standalone \
---set replicas=1 \
---set persistence.enabled=false \
---set buckets[0].name=hive,buckets[0].policy=none \
---set users[0].accessKey=hive,users[0].secretKey=hivehive,users[0].policy=readwrite \
---set resources.requests.memory=1Gi \
---set service.type=NodePort,service.nodePort=null \
---set consoleService.type=NodePort,consoleService.nodePort=null \
---repo https://charts.min.io/ minio
+  --version {{ versions.minio }} \
+  --namespace default \
+  --set mode=standalone \
+  --set replicas=1 \
+  --set persistence.enabled=false \
+  --set buckets[0].name=hive,buckets[0].policy=none \
+  --set users[0].accessKey=hive,users[0].secretKey=hivehive,users[0].policy=readwrite \
+  --set resources.requests.memory=1Gi \
+  --set service.type=NodePort,service.nodePort=null \
+  --set consoleService.type=NodePort,consoleService.nodePort=null \
+  --repo https://charts.min.io/ minio
 # end::helm-install-minio[]
 
 echo "Install postgres for Hive"
 # tag::helm-install-postgres[]
-helm install postgresql \
---version {{ versions.postgresql }} \
---namespace default \
---set auth.username=hive \
---set auth.password=hive \
---set auth.database=hive \
---set primary.extendedConfiguration="password_encryption=md5" \
---repo https://charts.bitnami.com/bitnami postgresql
+helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version {{ versions.postgresql }} \
+  --namespace default \
+  --set auth.username=hive \
+  --set auth.password=hive \
+  --set auth.database=hive \
+  --set primary.extendedConfiguration="password_encryption=md5" \
+  --wait
 # end::helm-install-postgres[]
 ;;
 "stackablectl")

--- a/docs/modules/hive/examples/getting_started/minio-stack.yaml
+++ b/docs/modules/hive/examples/getting_started/minio-stack.yaml
@@ -4,7 +4,7 @@ name: minio
 repo:
   name: minio
   url: https://charts.min.io/
-version: 4.0.2
+version: 5.4.0
 options:
   rootUser: root
   rootPassword: rootroot

--- a/docs/modules/hive/examples/getting_started/postgres-stack.yaml
+++ b/docs/modules/hive/examples/getting_started/postgres-stack.yaml
@@ -4,7 +4,7 @@ name: postgresql
 repo:
   name: bitnami
   url: https://charts.bitnami.com/bitnami/
-version: 12.1.5
+version: 16.5.0
 options:
   volumePermissions:
     enabled: false

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -7,5 +7,5 @@ versions:
   secret: 0.0.0-dev
   listener: 0.0.0-dev
   hive: 0.0.0-dev
-  minio: 4.0.2
-  postgresql: 12.1.5
+  minio: 5.4.0
+  postgresql: 16.5.0


### PR DESCRIPTION
# Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/697>

This PR bumps the following charts:

- `postgresql` to 16.5.0
- `minio` to 5.4.0 (N.B. this chart does not seem to be available from a registry so the helm callout has not been changed'

```shell
# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm
```
