### PR TITLE
test: Bump vector to 0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#589]).
+- test: Bump to Vector `0.46.1` ([#599]).
 
 ### Fixed
 
@@ -32,6 +33,7 @@ All notable changes to this project will be documented in this file.
 [#591]: https://github.com/stackabletech/hive-operator/pull/591
 [#592]: https://github.com/stackabletech/hive-operator/pull/592
 [#596]: https://github.com/stackabletech/hive-operator/pull/596
+[#599]: https://github.com/stackabletech/hive-operator/pull/599
 
 ## [25.3.0] - 2025-03-21
 

--- a/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install hive-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.39.0
+      --version 0.42.1
       --repo https://helm.vector.dev
       --values hive-vector-aggregator-values.yaml
 ---

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,24 +16,24 @@ dimensions:
       - "12.5.6"
   - name: hive
     values:
-      #- 3.1.3,local-hive:3.1.3
-      #- 4.0.0,local-hive:4.0.0
-      - 4.0.1,local-hive:4.0.1
+      - 3.1.3
+      - 4.0.0
+      - 4.0.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 4.0.1,oci.stackable.tech/sandbox/hive:4.0.1-stackable0.0.0-dev
   - name: hive-latest
     values:
-      - 4.0.1,local-hive:4.0.1
+      - 4.0.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 4.0.1,oci.stackable.tech/sandbox/hive:4.0.1-stackable0.0.0-dev
   - name: hive-old
     values:
-      - 3.1.3,local-hive:3.1.3
+      - 3.1.3
   - name: hive-new
     values:
-      - 4.0.1,local-hive:4.0.1
+      - 4.0.1
   - name: hdfs-latest
     values:
       - 3.4.1

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,24 +16,24 @@ dimensions:
       - "12.5.6"
   - name: hive
     values:
-      - 3.1.3
-      - 4.0.0
-      - 4.0.1
+      #- 3.1.3,local-hive:3.1.3
+      #- 4.0.0,local-hive:4.0.0
+      - 4.0.1,local-hive:4.0.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 4.0.1,oci.stackable.tech/sandbox/hive:4.0.1-stackable0.0.0-dev
   - name: hive-latest
     values:
-      - 4.0.1
+      - 4.0.1,local-hive:4.0.1
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 4.0.1,oci.stackable.tech/sandbox/hive:4.0.1-stackable0.0.0-dev
   - name: hive-old
     values:
-      - 3.1.3
+      - 3.1.3,local-hive:3.1.3
   - name: hive-new
     values:
-      - 4.0.1
+      - 4.0.1,local-hive:4.0.1
   - name: hdfs-latest
     values:
       - 3.4.1


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1085.

- Bump to Vector 0.46.1 (chart version 0.42.1) in tests

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
