### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#589]).
 - test: Bump to Vector `0.46.1` ([#599]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#603])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -34,6 +38,7 @@ All notable changes to this project will be documented in this file.
 [#592]: https://github.com/stackabletech/hive-operator/pull/592
 [#596]: https://github.com/stackabletech/hive-operator/pull/596
 [#599]: https://github.com/stackabletech/hive-operator/pull/599
+[#603]: https://github.com/stackabletech/hive-operator/pull/603
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -100,8 +100,6 @@ use crate::{
 pub const HIVE_CONTROLLER_NAME: &str = "hivecluster";
 pub const HIVE_FULL_CONTROLLER_NAME: &str = concatcp!(HIVE_CONTROLLER_NAME, '.', OPERATOR_NAME);
 
-/// Used as runAsUser in the pod security context
-pub const HIVE_UID: i64 = 1000;
 const DOCKER_IMAGE_BASE_NAME: &str = "hive";
 
 pub const MAX_HIVE_LOG_FILES_SIZE: MemoryQuantity = MemoryQuantity {
@@ -986,13 +984,7 @@ fn build_metastore_rolegroup_statefulset(
         .context(AddVolumeSnafu)?
         .affinity(&merged_config.affinity)
         .service_account_name(sa_name)
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(HIVE_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     if let Some(ContainerLogConfig {
         choice:

--- a/tests/templates/kuttl/kerberos-hdfs/35-access-hdfs.yaml.j2
+++ b/tests/templates/kuttl/kerberos-hdfs/35-access-hdfs.yaml.j2
@@ -65,7 +65,5 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF

--- a/tests/templates/kuttl/kerberos-hdfs/70-install-access-hive.yaml.j2
+++ b/tests/templates/kuttl/kerberos-hdfs/70-install-access-hive.yaml.j2
@@ -55,8 +55,6 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF
 ---

--- a/tests/templates/kuttl/kerberos-s3/70-install-access-hive.yaml.j2
+++ b/tests/templates/kuttl/kerberos-s3/70-install-access-hive.yaml.j2
@@ -55,8 +55,6 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF
 ---


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added
