### PR TITLE
tests: increase HiveCluster assert timeouts

### DIFF
--- a/tests/templates/kuttl/cluster-operation/10-assert.yaml
+++ b/tests/templates/kuttl/cluster-operation/10-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 commands:
   - script: kubectl -n "$NAMESPACE" wait --for=condition=available hiveclusters.hive.stackable.tech/test-hive --timeout 601s
 ---

--- a/tests/templates/kuttl/kerberos-hdfs/60-assert.yaml.j2
+++ b/tests/templates/kuttl/kerberos-hdfs/60-assert.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/kerberos-s3/60-assert.yaml.j2
+++ b/tests/templates/kuttl/kerberos-s3/60-assert.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/logging/04-assert.yaml
+++ b/tests/templates/kuttl/logging/04-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/orphaned-resources/01-assert.yaml
+++ b/tests/templates/kuttl/orphaned-resources/01-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-hive
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/resources/10-assert.yaml.j2
+++ b/tests/templates/kuttl/resources/10-assert.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/smoke/60-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/60-assert.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/upgrade/30-assert.yaml.j2
+++ b/tests/templates/kuttl/upgrade/30-assert.yaml.j2
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 900
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
## Description

Sometimes it takes longer than 10 minutes to create a `HiveCluster` in our weekly tests. I found test runs where for some reason the listener Pod on a node took a long time to start, which in turn blocked the Hive pods from starting. Mostly this succeeds shortly after the current timeout of 10 minutes, so I increased the timeout to 15 minutes. 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
