### PR TITLE
fix: Getting-started - Use listener for test access

### DIFF
--- a/docs/modules/hive/examples/getting_started/getting_started.sh
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh
@@ -115,4 +115,4 @@ kubectl rollout status --watch --timeout=5m statefulset/hive-test-helper
 # Only for testing the cluster (not required for documentation)
 echo "Running test scripts"
 kubectl cp -n default ../../../../../tests/templates/kuttl/smoke/test_metastore.py hive-test-helper-0:/tmp
-kubectl exec -n default hive-test-helper-0 -- python /tmp/test_metastore.py -m hive-postgres-s3-metastore-default-0.hive-postgres-s3-metastore-default.default.svc.cluster.local
+kubectl exec -n default hive-test-helper-0 -- python /tmp/test_metastore.py -m hive-postgres-s3-metastore

--- a/docs/modules/hive/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh.j2
@@ -115,4 +115,4 @@ kubectl rollout status --watch --timeout=5m statefulset/hive-test-helper
 # Only for testing the cluster (not required for documentation)
 echo "Running test scripts"
 kubectl cp -n default ../../../../../tests/templates/kuttl/smoke/test_metastore.py hive-test-helper-0:/tmp
-kubectl exec -n default hive-test-helper-0 -- python /tmp/test_metastore.py -m hive-postgres-s3-metastore-default-0.hive-postgres-s3-metastore-default.default.svc.cluster.local
+kubectl exec -n default hive-test-helper-0 -- python /tmp/test_metastore.py -m hive-postgres-s3-metastore


### PR DESCRIPTION
- Use listener address for testing access

## Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/742>

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
