### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be documented in this file.
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`,
+  so events can be aggregated (e.g. "error happened 10 times over the last 5 minutes") ([#617]).
 
 ### Fixed
 
@@ -57,6 +59,7 @@ All notable changes to this project will be documented in this file.
 [#605]: https://github.com/stackabletech/hive-operator/pull/605
 [#613]: https://github.com/stackabletech/hive-operator/pull/613
 [#615]: https://github.com/stackabletech/hive-operator/pull/615
+[#617]: https://github.com/stackabletech/hive-operator/pull/617
 
 ## [25.3.0] - 2025-03-21
 

--- a/deploy/helm/hive-operator/templates/roles.yaml
+++ b/deploy/helm/hive-operator/templates/roles.yaml
@@ -162,6 +162,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
