### PR TITLE
chore: update tests and docs to use bitnamilegacy

### DIFF
--- a/docs/modules/hive/examples/getting_started/getting_started.sh
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh
@@ -53,6 +53,10 @@ echo "Install postgres for Hive"
 helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version 16.5.0 \
   --namespace default \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.username=hive \
   --set auth.password=hive \
   --set auth.database=hive \

--- a/docs/modules/hive/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh.j2
@@ -53,6 +53,10 @@ echo "Install postgres for Hive"
 helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version {{ versions.postgresql }} \
   --namespace default \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.username=hive \
   --set auth.password=hive \
   --set auth.database=hive \

--- a/docs/modules/hive/examples/getting_started/postgres-stack.yaml
+++ b/docs/modules/hive/examples/getting_started/postgres-stack.yaml
@@ -6,10 +6,20 @@ repo:
   url: https://charts.bitnami.com/bitnami/
 version: 16.5.0
 options:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
     securityContext:
       runAsUser: auto
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   primary:
     extendedConfiguration: |
       password_encryption=md5

--- a/docs/modules/hive/examples/getting_started/postgres-stack.yaml.j2
+++ b/docs/modules/hive/examples/getting_started/postgres-stack.yaml.j2
@@ -6,10 +6,20 @@ repo:
   url: https://charts.bitnami.com/bitnami/
 version: {{ versions.postgresql }}
 options:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
     securityContext:
       runAsUser: auto
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   primary:
     extendedConfiguration: |
       password_encryption=md5

--- a/docs/modules/hive/pages/usage-guide/database-driver.adoc
+++ b/docs/modules/hive/pages/usage-guide/database-driver.adoc
@@ -10,6 +10,11 @@ To use another supported database it is necessary to make the relevant drivers a
 [source,bash]
 ----
 helm install mysql oci://registry-1.docker.io/bitnamicharts/mysql \
+--version=13.0.4 \
+--set image.repository=bitnamilegacy/mysql \
+--set volumePermissions.image.repository=bitnamilegacy/os-shell \
+--set metrics.image.repository=bitnamilegacy/mysqld-exporter \
+--set global.security.allowInsecureImages=true \
 --set auth.database=hive \
 --set auth.username=hive \
 --set auth.password=hive

--- a/docs/modules/hive/pages/usage-guide/derby-example.adoc
+++ b/docs/modules/hive/pages/usage-guide/derby-example.adoc
@@ -45,6 +45,11 @@ To create a single node Apache Hive Metastore (v4.0.1) cluster with derby and S3
 helm install minio \
     minio \
     --repo https://charts.bitnami.com/bitnami \
+    --set image.repository=bitnamilegacy/minio \
+    --set clientImage.repository=bitnamilegacy/minio-client \
+    --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set console.image.repository=bitnamilegacy/minio-object-browser \
+    --set global.security.allowInsecureImages=true \
     --set auth.rootUser=minio-access-key \
     --set auth.rootPassword=minio-secret-key
 ----
@@ -129,6 +134,10 @@ This installs PostgreSQL in version 10 to work around the issue mentioned above:
 [source,bash]
 ----
 helm install hive bitnami/postgresql --version=12.1.5 \
+--set image.repository=bitnamilegacy/postgresql \
+--set volumePermissions.image.repository=bitnamilegacy/os-shell \
+--set metrics.image.repository=bitnamilegacy/postgres-exporter \
+--set global.security.allowInsecureImages=true \
 --set postgresqlUsername=hive \
 --set postgresqlPassword=hive \
 --set postgresqlDatabase=hive

--- a/examples/simple-hive-cluster-postgres-s3.yaml
+++ b/examples/simple-hive-cluster-postgres-s3.yaml
@@ -3,9 +3,18 @@
 # helm install minio \
 #     minio \
 #     --repo https://charts.bitnami.com/bitnami \
+#     --set image.repository=bitnamilegacy/minio \
+#     --set clientImage.repository=bitnamilegacy/minio-client \
+#     --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+#     --set console.image.repository=bitnamilegacy/minio-object-browser \
+#     --set global.security.allowInsecureImages=true \
 #     --set auth.rootUser=minio-access-key \
 #     --set auth.rootPassword=minio-secret-key
 # helm install hive bitnami/postgresql --version=12.1.5 \
+# --set image.repository=bitnamilegacy/postgresql \
+# --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+# --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+# --set global.security.allowInsecureImages=true \
 # --set postgresqlUsername=hive \
 # --set postgresqlPassword=hive \
 # --set postgresqlDatabase=hive

--- a/tests/templates/kuttl/kerberos-hdfs/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/kerberos-hdfs/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |

--- a/tests/templates/kuttl/kerberos-s3/helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/kerberos-s3/helm-bitnami-minio-values.yaml.j2
@@ -1,4 +1,20 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:

--- a/tests/templates/kuttl/kerberos-s3/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/kerberos-s3/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |

--- a/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |

--- a/tests/templates/kuttl/smoke/helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-minio-values.yaml.j2
@@ -1,4 +1,20 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
 mode: standalone
 disableWebUI: false
 extraEnvVars:

--- a/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |

--- a/tests/templates/kuttl/upgrade/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/upgrade/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 Quickfix
This PR updates the tests and docs to use the bitnamylegacy repository for bitnami images. All affected tests, commands and getting started scripts ran successfully.

Integrationstests:
```
--- PASS: kuttl (635.40s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-4.0.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (370.21s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-3.1.3_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (370.67s)
        --- PASS: kuttl/harness/kerberos-hdfs_postgres-12.5.6_hive-4.0.0_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_openshift-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (265.17s)
PASS

--- PASS: kuttl (424.68s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-3.1.3_krb5-1.21.1_openshift-false_s3-use-tls-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (140.28s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-4.0.0_krb5-1.21.1_openshift-false_s3-use-tls-true_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (160.42s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-4.0.1_krb5-1.21.1_openshift-false_s3-use-tls-true_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (133.18s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-4.0.0_krb5-1.21.1_openshift-false_s3-use-tls-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (130.66s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-3.1.3_krb5-1.21.1_openshift-false_s3-use-tls-true_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (134.35s)
        --- PASS: kuttl/harness/kerberos-s3_postgres-12.5.6_hive-4.0.1_krb5-1.21.1_openshift-false_s3-use-tls-false_kerberos-realm-PROD.MYCORP_kerberos-backend-mit (133.60s)
PASS

--- PASS: kuttl (190.20s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.0.1_openshift-false (103.18s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-3.1.3_openshift-false (109.46s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.0.0_openshift-false (87.01s)
PASS

--- PASS: kuttl (383.28s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-3.1.3_openshift-false_s3-use-tls-false (129.67s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-4.0.0_openshift-false_s3-use-tls-true (142.24s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-4.0.0_openshift-false_s3-use-tls-false (120.81s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-3.1.3_openshift-false_s3-use-tls-true (123.06s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-4.0.1_openshift-false_s3-use-tls-true (127.82s)
        --- PASS: kuttl/harness/smoke_postgres-12.5.6_hive-4.0.1_openshift-false_s3-use-tls-false (117.95s)
PASS

--- PASS: kuttl (86.01s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/upgrade_postgres-12.5.6_hive-old-3.1.3_hive-new-4.0.1_openshift-false (85.98s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
