### PR TITLE
chore: update docs and examples to use bitnamilegacy

### DIFF
--- a/docs/modules/hive/examples/getting_started/getting_started.sh
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh
@@ -53,6 +53,10 @@ echo "Install postgres for Hive"
 helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version 16.5.0 \
   --namespace default \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.username=hive \
   --set auth.password=hive \
   --set auth.database=hive \

--- a/docs/modules/hive/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hive/examples/getting_started/getting_started.sh.j2
@@ -53,6 +53,10 @@ echo "Install postgres for Hive"
 helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version {{ versions.postgresql }} \
   --namespace default \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.username=hive \
   --set auth.password=hive \
   --set auth.database=hive \

--- a/docs/modules/hive/examples/getting_started/postgres-stack.yaml
+++ b/docs/modules/hive/examples/getting_started/postgres-stack.yaml
@@ -6,10 +6,20 @@ repo:
   url: https://charts.bitnami.com/bitnami/
 version: 16.5.0
 options:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
     securityContext:
       runAsUser: auto
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   primary:
     extendedConfiguration: |
       password_encryption=md5

--- a/docs/modules/hive/examples/getting_started/postgres-stack.yaml.j2
+++ b/docs/modules/hive/examples/getting_started/postgres-stack.yaml.j2
@@ -6,10 +6,20 @@ repo:
   url: https://charts.bitnami.com/bitnami/
 version: {{ versions.postgresql }}
 options:
+  global:
+    security:
+      allowInsecureImages: true
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     enabled: false
+    image:
+      repository: bitnamilegacy/os-shell
     securityContext:
       runAsUser: auto
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
   primary:
     extendedConfiguration: |
       password_encryption=md5

--- a/docs/modules/hive/pages/usage-guide/database-driver.adoc
+++ b/docs/modules/hive/pages/usage-guide/database-driver.adoc
@@ -10,6 +10,11 @@ To use another supported database it is necessary to make the relevant drivers a
 [source,bash]
 ----
 helm install mysql oci://registry-1.docker.io/bitnamicharts/mysql \
+--version=13.0.4 \
+--set image.repository=bitnamilegacy/mysql \
+--set volumePermissions.image.repository=bitnamilegacy/os-shell \
+--set metrics.image.repository=bitnamilegacy/mysqld-exporter \
+--set global.security.allowInsecureImages=true \
 --set auth.database=hive \
 --set auth.username=hive \
 --set auth.password=hive

--- a/docs/modules/hive/pages/usage-guide/derby-example.adoc
+++ b/docs/modules/hive/pages/usage-guide/derby-example.adoc
@@ -45,6 +45,11 @@ To create a single node Apache Hive Metastore (v4.0.1) cluster with derby and S3
 helm install minio \
     minio \
     --repo https://charts.bitnami.com/bitnami \
+    --set image.repository=bitnamilegacy/minio \
+    --set clientImage.repository=bitnamilegacy/minio-client \
+    --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set console.image.repository=bitnamilegacy/minio-object-browser \
+    --set global.security.allowInsecureImages=true \
     --set auth.rootUser=minio-access-key \
     --set auth.rootPassword=minio-secret-key
 ----
@@ -129,6 +134,10 @@ This installs PostgreSQL in version 10 to work around the issue mentioned above:
 [source,bash]
 ----
 helm install hive bitnami/postgresql --version=12.1.5 \
+--set image.repository=bitnamilegacy/postgresql \
+--set volumePermissions.image.repository=bitnamilegacy/os-shell \
+--set metrics.image.repository=bitnamilegacy/postgres-exporter \
+--set global.security.allowInsecureImages=true \
 --set postgresqlUsername=hive \
 --set postgresqlPassword=hive \
 --set postgresqlDatabase=hive

--- a/examples/simple-hive-cluster-postgres-s3.yaml
+++ b/examples/simple-hive-cluster-postgres-s3.yaml
@@ -3,9 +3,18 @@
 # helm install minio \
 #     minio \
 #     --repo https://charts.bitnami.com/bitnami \
+#     --set image.repository=bitnamilegacy/minio \
+#     --set clientImage.repository=bitnamilegacy/minio-client \
+#     --set defaultInitContainers.volumePermissions.image.repository=bitnamilegacy/os-shell \
+#     --set console.image.repository=bitnamilegacy/minio-object-browser \
+#     --set global.security.allowInsecureImages=true \
 #     --set auth.rootUser=minio-access-key \
 #     --set auth.rootPassword=minio-secret-key
 # helm install hive bitnami/postgresql --version=12.1.5 \
+# --set image.repository=bitnamilegacy/postgresql \
+# --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+# --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+# --set global.security.allowInsecureImages=true \
 # --set postgresqlUsername=hive \
 # --set postgresqlPassword=hive \
 # --set postgresqlDatabase=hive


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/hive-operator/pull/622
This PR updates the docs and examples of the 25.7 release to use bitnamilegacy.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
