### PR TITLE
Fix: Thrift connections string representation in reference docs

### DIFF
--- a/docs/modules/hive/pages/reference/discovery.adoc
+++ b/docs/modules/hive/pages/reference/discovery.adoc
@@ -58,7 +58,7 @@ The `{namespace}/{clusterName}` discovery ConfigMap contains the following field
 Contains the thrift protocol connection string for the Hive metastore service:
 
 [subs="attributes"]
-  thrift://{clusterName}.{namespace}.svc.cluster.local:{metastorePort}
+  thrift://{clusterName}-metastore.{namespace}.svc.cluster.local:{metastorePort}
 ====
 
 WARNING: Using the Hive metastore in high availability mode (replicas > 1) does not work with Derby but instead requires a properly configured database like PostgreSQL or MySQL.


### PR DESCRIPTION
## Description

fixes {cluster}-*metastore*.namespace.svc.cluster.local

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
