### PR TITLE
chore: Bump vector to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ All notable changes to this project will be documented in this file.
   This struct is consistent between different CRDs, so that you can easily copy/paste it between stacklets.
   Read on the [Hive database documentation](https://docs.stackable.tech/home/nightly/hive/usage-guide/database-driver) for details ([#674]).
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler ([#707]).
+- test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#713]).
 
 [#674]: https://github.com/stackabletech/hive-operator/pull/674
 [#693]: https://github.com/stackabletech/hive-operator/pull/693
 [#695]: https://github.com/stackabletech/hive-operator/pull/695
 [#702]: https://github.com/stackabletech/hive-operator/pull/702
 [#707]: https://github.com/stackabletech/hive-operator/pull/707
+[#713]: https://github.com/stackabletech/hive-operator/pull/713
 
 ## [26.3.0] - 2026-03-16
 

--- a/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install hive-vector-aggregator vector
       --namespace "$NAMESPACE"
-      --version 0.49.0
+      --version 0.52.0 `# app version 0.55.0`
       --repo https://helm.vector.dev
       --values hive-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/logging/test_log_aggregation.py
+++ b/tests/templates/kuttl/logging/test_log_aggregation.py
@@ -1,45 +1,40 @@
-#!/usr/bin/env python3
-import requests
+import json
+import subprocess
 
 
 def check_sent_events():
-    response = requests.post(
-        "http://hive-vector-aggregator:8686/graphql",
-        json={
-            "query": """
-                {
-                    transforms(first:100) {
-                        nodes {
-                            componentId
-                            metrics {
-                                sentEventsTotal {
-                                    sentEventsTotal
-                                }
-                            }
-                        }
-                    }
-                }
-            """
-        },
+    response = subprocess.run(
+        [
+            "grpcurl",
+            "-plaintext",
+            "-d",
+            '{"limit": 100}',
+            "hive-vector-aggregator:8686",
+            "vector.observability.v1.ObservabilityService/GetComponents",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,  # Raise a CalledProcessError if non-zero return
+        timeout=20,  # seconds
     )
+    result = json.loads(response.stdout)
+    components = result.get("components", [])
+    transforms = [
+        c for c in components if c.get("componentType") == "COMPONENT_TYPE_TRANSFORM"
+    ]
 
-    assert response.status_code == 200, (
-        "Cannot access the API of the vector aggregator."
-    )
+    assert len(transforms) > 0, "No transform components found"
 
-    result = response.json()
-
-    transforms = result["data"]["transforms"]["nodes"]
     for transform in transforms:
         sentEvents = transform["metrics"]["sentEventsTotal"]
         componentId = transform["componentId"]
 
         if componentId == "filteredInvalidEvents":
-            assert sentEvents is None or sentEvents["sentEventsTotal"] == 0, (
+            assert sentEvents is None or int(sentEvents) == 0, (
                 "Invalid log events were sent."
             )
         else:
-            assert sentEvents is not None and sentEvents["sentEventsTotal"] > 0, (
+            assert sentEvents is not None and int(sentEvents) > 0, (
                 f'No events were sent in "{componentId}".'
             )
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486

```
--- PASS: kuttl (688.05s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-3.1.3_openshift-false (173.63s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.1.0_openshift-false (175.13s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.2.0_openshift-false (156.22s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.0.1_openshift-false (155.60s)
        --- PASS: kuttl/harness/logging_postgres-12.5.6_hive-4.0.0_openshift-false (163.65s)
PASS
```