### PR TITLE
fix: Make serviceAccount.name and serviceAccount.create work

### DIFF
--- a/deploy/helm/hive-operator/templates/_helpers.tpl
+++ b/deploy/helm/hive-operator/templates/_helpers.tpl
@@ -65,9 +65,9 @@ Create the name of the service account to use
 */}}
 {{- define "operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "operator.fullname" .) .Values.serviceAccount.name }}
+{{- default (printf "%s-serviceaccount" (include "operator.fullname" .)) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- required "serviceAccount.name is required when serviceAccount.create is false, because the chart then does not create a ServiceAccount for the operator to run as." .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/hive-operator/templates/deployment.yaml
+++ b/deploy/helm/hive-operator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "operator.fullname" . }}-serviceaccount
+      serviceAccountName: {{ include "operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/helm/hive-operator/templates/serviceaccount.yaml
+++ b/deploy/helm/hive-operator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "operator.fullname" . }}-serviceaccount
+  name: {{ include "operator.serviceAccountName" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -20,7 +20,7 @@ metadata:
     {{- include "operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "operator.fullname" . }}-serviceaccount
+    name: {{ include "operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
## Description

serviceAccount.name had no effect.
The Deployment, the ServiceAccount and the ClusterRoleBinding all hardcoded "<fullname>-serviceaccount", and the
operator.serviceAccountName helper that we built already was never used :partying_face: 
 
serviceAccount.create: false also skipped creating the ServiceAccount while the Deployment still referenced the name that no longer existed. So that's not good either.
 
This changes it so that the helper is used everywhere, default name is unchanged and with "create: false" giving a name is now required.

I'd call this a bug fix as well. Debatable whether this is a breaking change....

> [!NOTE]
> I understand that this needs to be fixed in operator-templating but I want to test all my changes on hive operator first and if all those changes are accepted I'll bring them to templating! 

Claude created this table for me (CRB = ClusterRoleBinding):

| scenario | ServiceAccount | CRB subject | Deployment |
|---|---|---|---|
| default | `rel-hive-operator-serviceaccount` | same | same |
| `name=my-sa` | `my-sa` | `my-sa` | `my-sa` |
| `create=false`, `name=my-sa` | not created | not created | `my-sa` |
| `create=false`, no name | fails at template time | | |

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
