### PR TITLE
tests: Fix removed thrift function and missing opa rule

### DIFF
--- a/tests/templates/kuttl/smoke/50-install-opa.yaml.j2
+++ b/tests/templates/kuttl/smoke/50-install-opa.yaml.j2
@@ -85,14 +85,14 @@ data:
       input.identity.username == stackable_user
       input.resources.table.dbName == db_name
       input.privileges.writeRequiredPriv[0].priv == "CREATE"
-      input.resources.table.tableName in ["s3_one_column_table", "one_column_table"]
+      input.resources.table.tableName in ["s3_one_column_table", "one_column_table", "s3_scheme_one_column_table"]
     }
 
     table_allow if {
       input.identity.username == stackable_user
       input.resources.table.dbName == db_name
       input.privileges.readRequiredPriv[0].priv == "SELECT"
-      input.resources.table.tableName in ["s3_one_column_table", "one_column_table"]
+      input.resources.table.tableName in ["s3_one_column_table", "one_column_table", "s3_scheme_one_column_table"]
     }
 
     column_allow if {

--- a/tests/templates/kuttl/smoke/test_metastore.py
+++ b/tests/templates/kuttl/smoke/test_metastore.py
@@ -10,6 +10,7 @@ from hive_metastore_client.builders import (
 from thrift_files.libraries.thrift_hive_metastore_client.ttypes import (
     FieldSchema,
     AlreadyExistsException,
+    GetTableRequest,
 )
 import argparse
 
@@ -58,9 +59,9 @@ def check_table(hive_client, db_name, table_name, location, label):
         )
         exit(-1)
 
-    # Positional arguments on purpose: get_table takes `dbname`/`tbl_name`, unlike
-    # get_schema above, which takes `db_name`/`table_name`.
-    return hive_client.get_table(db_name, table_name)
+    return hive_client.get_table_req(
+        GetTableRequest(dbName=db_name, tblName=table_name)
+    ).table
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Tested with 4.2.0/4.0.1 smoke test on Openshift.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
