### PR TITLE
docs: Add NOTES.txt and document the values only the schema mentioned

### DIFF
--- a/deploy/helm/hive-operator/templates/NOTES.txt
+++ b/deploy/helm/hive-operator/templates/NOTES.txt
@@ -1,0 +1,19 @@
+{{ .Chart.Name }} {{ .Chart.AppVersion }} is installed in namespace {{ .Release.Namespace }}.
+
+This installs the Stackable operator for Apache Hive only.
+
+Find more information in our documentation:
+
+* https://docs.stackable.tech/home/stable/hive/
+* https://hub.stackable.tech/components/hive
+{{ if .Values.maintenance.customResourceDefinitions.maintain }}
+The operator installs and updates its own CustomResourceDefinitions when it starts, so the chart
+does not ship them. They appear shortly after the pod becomes ready.
+{{- else }}
+WARNING: maintenance.customResourceDefinitions.maintain is false, so this operator will not install
+its CustomResourceDefinitions and the chart does not ship them either. Apply them yourself before
+creating any resources managed by this operator, otherwise the API server will reject them.
+{{- end }}
+
+Learn more at https://stackable.tech
+Thank you for using Stackable!

--- a/deploy/helm/hive-operator/values.schema.json
+++ b/deploy/helm/hive-operator/values.schema.json
@@ -153,19 +153,19 @@
       "title": "Node selector",
       "type": "object",
       "default": {},
-      "description": "Node labels the operator pod must match to be scheduled."
+      "description": "Node labels the operator pod must match to be scheduled. Product pods are placed by their own custom resource, not here."
     },
     "tolerations": {
       "title": "Tolerations",
       "type": "array",
       "default": [],
-      "description": "Taints the operator pod tolerates."
+      "description": "Taints the operator pod tolerates. Product pods take their tolerations from their own custom resource, not here."
     },
     "affinity": {
       "title": "Affinity",
       "type": "object",
       "default": {},
-      "description": "Affinity and anti-affinity rules for the operator pod."
+      "description": "Affinity and anti-affinity rules for the operator pod. Product pod affinity is configured in their own custom resource, not here."
     },
     "priorityClassName": {
       "title": "Priority class name",
@@ -323,6 +323,11 @@
           ]
         }
       }
+    },
+    "global": {
+      "title": "Global values",
+      "description": "Values shared with parent and sibling charts when this chart is used as a subchart. Not read by this chart.",
+      "type": "object"
     }
   },
   "definitions": {

--- a/deploy/helm/hive-operator/values.yaml
+++ b/deploy/helm/hive-operator/values.yaml
@@ -1,6 +1,19 @@
 # Default values for hive-operator.
 ---
 image:
+  # Registry and namespace holding the operator image, without the image name.
+  # Set when the chart is packaged, from the registry it is published to, so it is
+  # normally already correct. Override it to pull from a mirror.
+  # repository: oci.stackable.tech/sdp
+
+  # Registry and namespace holding the product images, if they should come from
+  # somewhere other than image.repository. Credentials for that registry are
+  # configured per cluster in spec.image.pullSecrets on the custom resource, not here.
+  # productRepository: oci.stackable.tech/sdp
+
+  # Overrides the operator image tag, which defaults to the chart appVersion.
+  # tag: 0.0.0-dev
+
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -13,7 +26,9 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # Leave empty to use the generated name, <release>-hive-operator-serviceaccount.
+  # Required when create is false, so that the Deployment and the ClusterRoleBinding
+  # know which existing service account to use.
   name: ""
 
 podAnnotations: {}
@@ -46,6 +61,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# PriorityClass for the operator pod. Unset means the cluster default.
+# priorityClassName: system-cluster-critical
 
 # When running on a non-default Kubernetes cluster domain, the cluster domain can be configured here.
 # See the https://docs.stackable.tech/home/stable/guides/kubernetes-cluster-domain guide for details.


### PR DESCRIPTION
Two "documentation" things:

* A `NOTEST.txt` file: This is printed to stdout after every installation using `helm install`
* `helm show values` shows the values file but not the schema. We already document some of the properties in a "commented" out fashion. This also adds the remaining ones so they are easier to discover